### PR TITLE
v0.20.4 -- position fixed the body element when mobile navigation in view 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.20.4
+------------------------------
+*February 20, 2018*
+
+### Fixed
+- Fixed issue when opening the mobile navigation and content still allowed to scroll.
+
 v0.20.3
 ------------------------------
 *February 19, 2018*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/scss/partials/_nav.scss
+++ b/src/scss/partials/_nav.scss
@@ -41,6 +41,10 @@ $nav-popover-padding          : spacing(x2);
 .is-navInView {
     @include media('<mid') {
         overflow: hidden;
+        body {
+            position: fixed;
+            width: 100%;
+        }
     }
 }
 


### PR DESCRIPTION
v0.20.4 -- position fixed the body element when mobile navigation iniew as background content scrollable in iOS devices

## UI Review Checks

![image](https://media.github.je-labs.com/user/326/files/c1e6632c-e23e-11e6-91e2-4625e4f89d6d)

## Browsers Tested

- [x] Chrome
- [x] Internet Explorer [9|10]
- [x] Mobile (i.e. iPhone/Android - iPhone (iOS 9,10,11), iPad (iOS 8,11), Android S8, S7, Pixel, Nexus)


