### PR TITLE
v0.21.2 - Fix incorrect link text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.21.2
+------------------------------
+*April 9, 2018*
+
+### Fixed
+- Fix typo in link.
+
 v0.21.1
 ------------------------------
 *April 5, 2018*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/templates/resources/header.json
+++ b/src/templates/resources/header.json
@@ -42,7 +42,7 @@
         "paymentMethods": "Your saved cards",
         "deliveryAddresses": "Your address book",
         "redeemVoucher": "Redeem a voucher",
-        "contactPreferences": "Contact preference"
+        "contactPreferences": "Contact preferences"
     },
     "en-IE": {
         "companyName": "Just Eat",


### PR DESCRIPTION
Change link text for `contactPreferences` to match UK production.

![image](https://user-images.githubusercontent.com/1439341/38454602-0b354cb0-3a62-11e8-8f59-14b15ff89d1e.png)
