### PR TITLE
0.23.0 - Conditional "target=_blank" for the help menu link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.23.0
+------------------------------
+*April 16, 2018*
+
+### Added
+- Conditional `target="_blank"` for the help menu link
+
+
 v0.22.1
 ------------------------------
 *April 12, 2018*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/templates/header/index.hbs
+++ b/src/templates/header/index.hbs
@@ -42,9 +42,15 @@
                     {{> nav-alternate-language-links }}
 
                     <li class="c-nav-list-item c-nav-list-item--support" data-test-id="support">
-                        <a href="{{ helpUrl }}" data-gtm="header|click - navigation|help" class="c-nav-list-link">
-                            {{ i18n "helpLinkText" }}
-                        </a>
+                        {{#if isHelpExternal}}
+                            <a href="{{ helpUrl }}" target="_blank" data-gtm="header|click - navigation|help" class="c-nav-list-link">
+                                {{ i18n "helpLinkText" }}
+                            </a>
+                        {{else}}
+                            <a href="{{ helpUrl }}" data-gtm="header|click - navigation|help" class="c-nav-list-link">
+                                {{ i18n "helpLinkText" }}
+                            </a>
+                        {{/if}}
                     </li>
                 </ul>
             </div>

--- a/src/templates/header/index.hbs
+++ b/src/templates/header/index.hbs
@@ -42,15 +42,9 @@
                     {{> nav-alternate-language-links }}
 
                     <li class="c-nav-list-item c-nav-list-item--support" data-test-id="support">
-                        {{#if isHelpExternal}}
-                            <a href="{{ helpUrl }}" target="_blank" data-gtm="header|click - navigation|help" class="c-nav-list-link">
-                                {{ i18n "helpLinkText" }}
-                            </a>
-                        {{else}}
-                            <a href="{{ helpUrl }}" data-gtm="header|click - navigation|help" class="c-nav-list-link">
-                                {{ i18n "helpLinkText" }}
-                            </a>
-                        {{/if}}
+                        <a href="{{ helpUrl }}" {{#if isHelpExternal}}target="_blank"{{/if}} data-gtm="header|click - navigation|help" class="c-nav-list-link">
+                            {{ i18n "helpLinkText" }}
+                        </a>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
Looks like adding if/else statement is not an optimal way to do this change, but conditional syntax 
`target="{{if isHelpExternal "_blank"}}"` didn't work...
https://guides.emberjs.com/v3.0.0/templates/conditionals/