### PR TITLE
v0.25.0 : Changed nav font size to base--scaleUp size.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.25.0
+------------------------------
+*April 24, 2018*
+
+### Changed
+- `$nav-text-size` to use new `base--scaleUp` property from the `fozzie` `$type` map.
 
 v0.24.0
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/scss/partials/_nav.scss
+++ b/src/scss/partials/_nav.scss
@@ -6,7 +6,7 @@
  */
 
 $nav-trigger-length           : 56px;
-$nav-text-size                : 'mid';
+$nav-text-size                : 'base--scaleUp';
 $nav-text-font                : $font-family-headings;
 $nav-text-color               : $blue;
 $nav-text-weight              : 500;


### PR DESCRIPTION
The header navigation used to be 16px some changes I made in fozzie caused the navigation font size to increase. I've added a new property to our `$type` map to fix this.