### PR TITLE
v0.29.0 — Improving the compile script.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.29.0
+------------------------------
+*June 15, 2018*
+
+### Added
+- rimraf dev dependency.
+- Script to clean the `dist` directory before transpiling code which runs before compile script.
+- snyk badge.
+
+### Changed
+- Prevent adding unit test files to the `dist` directory.
+
+### Removed
+- Removed the gemnasium badge from the readme.
+
+
 v0.28.0
 ------------------------------
 *June 15, 2018*

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://badge.fury.io/js/%40justeat%2Ff-header.svg)](https://badge.fury.io/js/%40justeat%2Ff-header)
 [![Build Status](https://travis-ci.org/justeat/f-header.svg)](https://travis-ci.org/justeat/f-header)
 [![Coverage Status](https://coveralls.io/repos/github/justeat/f-header/badge.svg)](https://coveralls.io/github/justeat/f-header)
-[![Dependency Status](https://gemnasium.com/badges/github.com/justeat/f-header.svg)](https://gemnasium.com/github.com/justeat/f-header)
+[![Known Vulnerabilities](https://snyk.io/test/github/justeat/f-header/badge.svg?targetFile=package.json)](https://snyk.io/test/github/justeat/f-header?targetFile=package.json)
 
 Fozzie Header Component – allows any project to install and use a variation of the Just Eat header on their project.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",
@@ -40,7 +40,8 @@
     "gulp": "^3.9.1",
     "jest-fetch-mock": "^1.5.0",
     "jest-localstorage-mock": "^2.2.0",
-    "js-test-buddy": "^0.1.0"
+    "js-test-buddy": "^0.1.0",
+    "rimraf": "^2.6.2"
   },
   "keywords": [
     "fozzie",
@@ -54,10 +55,11 @@
   },
   "scripts": {
     "prepare": "concurrently -n \"lint,compile,test\" -c \"blue,yellow,green\" \"yarn lint\" \"yarn compile\" \"yarn test:cover\" --kill-others-on-fail",
+    "clean": "rimraf dist",
     "lint": "yarn run lint:css && yarn run lint:js",
     "lint:css": "gulp scss:lint --prod",
     "lint:js": "gulp scripts:lint --prod",
-    "compile": "babel -d dist src",
+    "compile": "yarn clean && babel -d dist src --ignore test.js",
     "test:cover": "gulp scripts:test:coverage",
     "test:cover:CI": "cat coverage/lcov.info | coveralls"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11095,6 +11095,12 @@ rimraf@2, rimraf@^2.2.6, rimraf@^2.2.8, rimraf@^2.4.3, rimraf@^2.5.1, rimraf@^2.
   dependencies:
     glob "^7.0.5"
 
+rimraf@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
+  dependencies:
+    glob "^7.0.5"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.1.tgz#0f4584295c53a3628af7e6d79aca21ce57d1c6e7"


### PR DESCRIPTION
### Added
- rimraf dev dependency.
- Script to clean the `dist` directory before transpiling code which runs before compile script.

### Changed
- Prevent adding unit test files to the `dist` directory.

### Removed
- Removed the gemnasium badge from the readme.