### PR TITLE
v0.34.0 - update of burger icon for consistency with f-icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.34.0
+------------------------------
+*August 23, 2018*
+
+### Changed
+- Updated burger menu icon to be consistent with JustEats current icon pack
+
 v0.33.0
 ------------------------------
 *August 23, 2018*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/scss/partials/_nav.scss
+++ b/src/scss/partials/_nav.scss
@@ -20,7 +20,7 @@ $nav-toggleIcon-height        : 1px;
 $nav-toggleIcon-borderRadius  : 1px;
 $nav-toggleIcon-color         : $blue !default;
 $nav-toggleIcon-bg            : $white;
-$nav-toggleIcon-space         : 6px;
+$nav-toggleIcon-space         : 1px;
 $nav-transition-duration      : 250ms;
 $nav-tooltip-width            : 10px;
 $nav-popover-width            : 300px;
@@ -345,10 +345,10 @@ $nav-popover-padding          : spacing(x2);
             transition: all $nav-transition-duration ease-in-out;
         }
         &:before {
-            top: -($nav-toggleIcon-space);
+            top: -($nav-toggleIcon-space + $nav-toggleIcon-height);
         }
         &:after {
-            top: $nav-toggleIcon-space;
+            top: ($nav-toggleIcon-space + $nav-toggleIcon-height);
         }
     }
 

--- a/src/scss/partials/_nav.scss
+++ b/src/scss/partials/_nav.scss
@@ -20,7 +20,7 @@ $nav-toggleIcon-height        : 1px;
 $nav-toggleIcon-borderRadius  : 1px;
 $nav-toggleIcon-color         : $blue !default;
 $nav-toggleIcon-bg            : $white;
-$nav-toggleIcon-space         : 1px;
+$nav-toggleIcon-space         : 5px;
 $nav-transition-duration      : 250ms;
 $nav-tooltip-width            : 10px;
 $nav-popover-width            : 300px;

--- a/src/scss/partials/_nav.scss
+++ b/src/scss/partials/_nav.scss
@@ -16,7 +16,8 @@ $nav-text-color--narrow       : $grey--dark;
 $nav-icon-color               : $blue !default;
 $nav-toggleIcon-left          : spacing(x2);
 $nav-toggleIcon-width         : spacing(x3);
-$nav-toggleIcon-height        : 3px;
+$nav-toggleIcon-height        : 1px;
+$nav-toggleIcon-borderRadius  : 1px;
 $nav-toggleIcon-color         : $blue !default;
 $nav-toggleIcon-bg            : $white;
 $nav-toggleIcon-space         : 6px;
@@ -333,6 +334,7 @@ $nav-popover-padding          : spacing(x2);
             position: absolute;
             height: $nav-toggleIcon-height;
             background-color: $nav-toggleIcon-color;
+            border-radius: $nav-toggleIcon-borderRadius;
         }
 
         &:before,
@@ -343,10 +345,10 @@ $nav-popover-padding          : spacing(x2);
             transition: all $nav-transition-duration ease-in-out;
         }
         &:before {
-            top: -($nav-toggleIcon-space + $nav-toggleIcon-height);
+            top: -($nav-toggleIcon-space);
         }
         &:after {
-            top: ($nav-toggleIcon-space + $nav-toggleIcon-height);
+            top: $nav-toggleIcon-space;
         }
     }
 


### PR DESCRIPTION
__*update of burger icon for consistency with f-icons*__

Before:
<img width="76" alt="screen shot 2018-08-22 at 16 46 29" src="https://user-images.githubusercontent.com/5295718/44474798-669a6880-a62b-11e8-9ff8-b6b893032326.png">

After:
<img width="64" alt="screen shot 2018-08-22 at 16 45 33" src="https://user-images.githubusercontent.com/5295718/44474803-68642c00-a62b-11e8-93f4-36c99c51a12d.png">

## UI Review Checks

- [x] This PR has been checked with regard to our brand guidelines
- [x] Mobile

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)
