### PR TITLE
v0.35.0 - Add qps-ploc resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.35.0
+------------------------------
+*August 29, 2018*
+
+### Changed
+- Added pseudo-locale `qps-ploc` for localisation testing on Windows.
+
 v0.34.0
 ------------------------------
 *August 23, 2018*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/templates/resources/header.json
+++ b/src/templates/resources/header.json
@@ -153,5 +153,23 @@
         "accountCredit": "Gavekort saldo",
         "paymentMethods": "",
         "deliveryAddresses": "Leveringsadresse"
+    },
+    "qps-ploc": {
+        "companyName": "[Ĵûšţẋẋ Éåţẋ]",
+        "openMenuText": "[Öþéñẋẋ Ṁéñûẋẋ]",
+        "loginLinkText": "[Ļöĝ‐îñẋẋ]",
+        "loginNoScriptLinkText": "[Åççöûñţẋẋẋ]",
+        "logoAltText": "[Ĵûšţẋẋ Éåţẋ ‐ẋ Öñļîñéẋẋ Ţåķéåŵåýẋẋẋ]",
+        "helpLinkText": "[Ĥéļþẋẋ]",
+        "logoutLinkText": "[Ļöĝẋ öûţẋ]",
+        "skipToMainContentText": "[Šķîþẋẋ ţöẋ ɱåîñẋẋ çöñţéñţẋẋẋ]",
+        "accountInfo": "[Ýöûŕẋẋ åççöûñţẋẋẋ]",
+        "accountOrderHistory": "[Ýöûŕẋẋ öŕðéŕšẋẋ]",
+        "paymentMethods": "[Ýöûŕẋẋ šåṽéðẋẋ çåŕðšẋẋ]",
+        "deliveryAddresses": "[Ýöûŕẋẋ åððŕéššẋẋẋ ƀööķẋẋ]",
+        "redeemVoucher": "[Ŕéðééɱẋẋ åẋ ṽöûçĥéŕẋẋẋ]",
+        "contactPreferences": "[Çöñţåçţẋẋẋ þŕéƒéŕéñçéšẋẋẋẋ]",
+        "languageSwitcherAccessibility": "[Çĥåñĝéẋẋ ţĥéẋ ļåñĝûåĝéẋẋẋ ţöẋ]",
+        "languageSwitcherName": "[Éñĝļîšĥẋẋẋ]"
     }
 }


### PR DESCRIPTION
This PR adds pseudo-localised English for `qps-ploc` to allow localisation testing on Windows ([docs](https://docs.microsoft.com/en-us/windows/desktop/intl/using-pseudo-locales-for-localization-testing)).

Values were generated using my custom fork of [anderskaplan/Pseudolocalizer](https://github.com/anderskaplan/Pseudolocalizer):

https://github.com/martincostello/Pseudolocalizer/tree/xliff-support
