### PR TITLE
v0.42.0 - removal of input to button conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.42.0
+------------------------------
+*October 5, 2018*
+
+### Changed
+- Updated `data-nav-enhance` to `data-nav-button` and `data-nav-accessible-button` to work with non-js accessible menu markup
+- Updated unit tests to work after removal of `data-nav-enhance`
+
+### Removed
+- Removed JS functionality to convert input to a button as creates a bug in Chrome checkbox selection
+
+
 v0.41.0
 ------------------------------
 *October 4, 2018*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -7,42 +7,20 @@
 import ready from 'lite-ready';
 import { checkForUser } from './userAuth';
 
-
-/**
- * Converts an input to a button in order to improve accessibility.
- *
- * @param {string} selector
- */
-const convertInputToButton = selector => {
-    const input = document.querySelector(selector);
-
-    if (input) {
-        const replaceTag = input.outerHTML.replace(/^<input/, '<button');
-        input.outerHTML = `${replaceTag}</button>`;
-
-        // Query the DOM again for this element now it has changed to a button
-        const button = document.querySelector(selector);
-        button.setAttribute('type', 'button');
-
-        return button;
-    }
-
-    return null;
-};
-
 /**
  * Setup the behaviour for the header component.
  */
 const setupHeader = () => {
-    const menuButton = convertInputToButton('[data-nav-enhance]');
+    const menuButton = document.querySelector('[data-nav-button]');
+    const accessibleButton = document.querySelector('[data-nav-accessible-button]');
+
+    if (accessibleButton) {
+        accessibleButton.classList.remove('is-shown--noJS');
+        accessibleButton.classList.add('is-hidden');
+    }
 
     if (menuButton) {
-        /**
-         * Attach click event handler — as this element is now a button this event will
-         * trigger when the `enter` and `spacebar` keys are pressed.
-         *
-         * @see {@link https://www.w3.org/TR/html51/editing.html#running-synthetic-click-activation-steps - synthetic click activation steps}
-         */
+        menuButton.classList.remove('is-hidden--noJS');
         menuButton.addEventListener('click', () => {
             const navContainer = document.querySelector('[data-nav-container]');
             const navLabel = document.querySelector('[data-nav-toggle]');

--- a/src/js/test/index.test.js
+++ b/src/js/test/index.test.js
@@ -9,10 +9,24 @@ describe('module', () => {
 });
 
 describe('setupHeader', () => {
-    it('converts nav checkbox to button with correct type attribute', () => {
+    it('removes `is-shown--noJS` class from the accessible nav button', () => {
         // Arrange
         TestUtils.setBodyHtml(`
-            <input data-nav-enhance />
+            <input data-nav-accessible-button class="is-shown--noJS" />
+        `);
+
+        // Act
+        setupHeader();
+
+        // Assert
+        const html = TestUtils.getBodyHtml();
+        expect(html).toMatchSnapshot();
+    });
+
+    it('adds `is-hidden` class to the accessible nav button', () => {
+        // Arrange
+        TestUtils.setBodyHtml(`
+            <input data-nav-accessible-button class="is-shown--noJS" />
         `);
 
         // Act
@@ -26,11 +40,11 @@ describe('setupHeader', () => {
     it('adds `is-visible` class to nav container', () => {
         // Arrange
         TestUtils.setBodyHtml(`
-            <input data-nav-enhance />
+            <button data-nav-button></button>
             <div data-nav-container></div>
         `);
         setupHeader();
-        const button = document.querySelector('button[data-nav-enhance]');
+        const button = document.querySelector('[data-nav-enhance]');
 
         // Act
         TestUtils.click(button);
@@ -43,11 +57,11 @@ describe('setupHeader', () => {
     it('adds `is-open` class to nav label', () => {
         // Arrange
         TestUtils.setBodyHtml(`
-            <input data-nav-enhance />
+            <button data-nav-button></button>
             <label data-nav-toggle>Menu</label>
         `);
         setupHeader();
-        const button = document.querySelector('button[data-nav-enhance]');
+        const button = document.querySelector('[data-nav-enhance]');
 
         // Act
         TestUtils.click(button);
@@ -78,10 +92,10 @@ describe('setupHeader', () => {
     it('adds `is-navInView` class to html element', () => {
         // Arrange
         TestUtils.setBodyHtml(`
-            <input data-nav-enhance />
+            <button data-nav-button></button>
         `);
         setupHeader();
-        const button = document.querySelector('button[data-nav-enhance]');
+        const button = document.querySelector('[data-nav-button]');
 
         // Act
         TestUtils.click(button);

--- a/src/templates/header/index.hbs
+++ b/src/templates/header/index.hbs
@@ -9,7 +9,8 @@
         {{> logo }}
 
         <nav data-navglobal class="c-nav c-nav--global">
-            <input data-nav-enhance type="checkbox" class="c-nav-trigger" id="nav-trigger" />
+            <button data-nav-button class="c-nav-trigger is-hidden--noJS">{{ i18n "openMenuText" }}</button>
+            <input  data-nav-accessible-button type="checkbox" class="c-nav-trigger is-shown--noJS" id="nav-trigger" />
 
             <label data-nav-toggle class="c-nav-toggle" for="nav-trigger">
                 <span class="c-nav-toggle-icon">{{ i18n "openMenuText" }}</span>


### PR DESCRIPTION
 removal of input to button JS conversion, update with static approach

- Updated `data-nav-enhance` to `data-nav-button` and `data-nav-accessible-button` to work with static accessible menu markup
- Updated unit tests to work after removal of `data-nav-enhance`
- Removed JS functionality to convert input to a button as creates a bug in Chrome checkbox selection

## UI Review Checks

- [x] This PR has been checked with regard to our brand guidelines
- [x] This code has been checked with regard to our accessibility standards

## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile