### PR TITLE
v0.46.0 - update of zindex on c-header-button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.46.0
+------------------------------
+*October 22, 2018*
+
+### Changed
+- Changed `z-index` on `c-header-button` to `high - 1` to stop elm showing when popover components are active
+
 v0.45.0
 ------------------------------
 *October 12, 2018*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ v0.46.0
 ### Changed
 - Changed `z-index` on `c-header-button` to `high - 1` to stop elm showing when popover components are active
 
+
 v0.45.0
 ------------------------------
 *October 12, 2018*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@justeat/f-logger": "^0.7.1",
     "@justeat/f-utils": "^0.1.0",
-    "@justeat/fozzie": "^1.6.0",
+    "@justeat/fozzie": "^1.7.0",
     "@justeat/fozzie-colour-palette": "^2.1.0",
     "include-media": "^1.4.9",
     "lite-ready": "^1.0.4"

--- a/src/scss/partials/_header.scss
+++ b/src/scss/partials/_header.scss
@@ -98,7 +98,7 @@ $header--transparent-opacity        : 0.7;
         right: spacing();
         padding: spacing();
         position: absolute;
-        z-index: 8999;
+        z-index: zIndex(belowHighest);
 
         .is-sticky & {
             top: -47px;

--- a/src/scss/partials/_header.scss
+++ b/src/scss/partials/_header.scss
@@ -98,7 +98,7 @@ $header--transparent-opacity        : 0.7;
         right: spacing();
         padding: spacing();
         position: absolute;
-        z-index: zIndex(high);
+        z-index: zIndex(high) - 1;
 
         .is-sticky & {
             top: -47px;

--- a/src/scss/partials/_header.scss
+++ b/src/scss/partials/_header.scss
@@ -98,7 +98,7 @@ $header--transparent-opacity        : 0.7;
         right: spacing();
         padding: spacing();
         position: absolute;
-        z-index: zIndex(high) - 1;
+        z-index: 8999;
 
         .is-sticky & {
             top: -47px;


### PR DESCRIPTION
- Changed `z-index` on `c-header-button` to `high - 1` to stop elm showing when popover components are active

Before:
<img width="192" alt="screen shot 2018-10-22 at 11 02 17" src="https://user-images.githubusercontent.com/5295718/47287393-0489bf80-d5ea-11e8-9de6-c99959129f10.png">


After:
<img width="181" alt="screen shot 2018-10-22 at 11 02 32" src="https://user-images.githubusercontent.com/5295718/47287400-0784b000-d5ea-11e8-9178-26e2c12443b6.png">


## UI Review Checks

- [x] This PR has been checked with regard to our brand guidelines

## Browsers Tested

- [x] Chrome
- [x] Mobile (i.e. iPhone/Android - please list device)
