### PR TITLE
v0.47.0 - addition of styles for `c-header-buttonCount`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.47.0
+------------------------------
+*October 23, 2018*
+
+### Added
+- Added styles for `c-header-buttonCount`.
+
+
 v0.46.0
 ------------------------------
 *October 22, 2018*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/scss/partials/_header.scss
+++ b/src/scss/partials/_header.scss
@@ -19,6 +19,8 @@ $header--transparent-opacity        : 0.7;
 // Menulog theme overrides
 @if ($theme == 'ml') {
     $header-buttonIcon-color: $green;
+    $header-buttonIcon-color: $green;
+    $header-buttonCount-bg  : $green;
 }
 
 

--- a/src/scss/partials/_header.scss
+++ b/src/scss/partials/_header.scss
@@ -6,6 +6,10 @@ $header-separator                   : 1px;
 $header-separator                   : 4px;
 $header-border-color                : $grey--lightest;
 $header-buttonIcon-color            : $blue;
+$header-buttonCount-bg              : $blue;
+$header-buttonCount-color           : $white;
+$header-buttonCount-borderColor     : $white;
+
 
 $header--transparent-gradient-color : $black;
 $header--transparent-gradient       : 115px;
@@ -112,4 +116,18 @@ $header--transparent-opacity        : 0.7;
         svg {
             fill: $header-buttonIcon-color;
         }
+    }
+
+    .c-header-buttonCount {
+        top: 0;
+        right: 0;
+        min-width: 16px;
+        padding: 1px 3px 0;
+        text-align: center;
+        border-radius: 8px;
+        position: absolute;
+        @include font-size(small, false);
+        color: $header-buttonCount-color;
+        background: $header-buttonCount-bg;
+        border: 1px solid $header-buttonCount-borderColor;
     }


### PR DESCRIPTION
 - addition of styles for `c-header-buttonCount`

## UI Review Checks

<img width="100" alt="screen shot 2018-10-22 at 13 15 30" src="https://user-images.githubusercontent.com/5295718/47302854-6cf09500-d61a-11e8-9b9b-41e2710cb3a1.png">
<img width="85" alt="screen shot 2018-10-22 at 13 15 37" src="https://user-images.githubusercontent.com/5295718/47302855-6d892b80-d61a-11e8-91bc-a6cec95b0904.png">



- [x] This PR has been checked with regard to our brand guidelines
- [x] This code has been checked with regard to our accessibility standards

## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [x] Mobile 