### PR TITLE
v1.0.2 Fixed menulog logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.0.2
+------------------------------
+*November 6, 2018*
+
+### Fixed
+- Fixed Menulog logo positioning. Also removed the logo outline in transparent mode so if background colour changes we won't need to update the logo. 
+
 v1.0.1
 ------------------------------
 *November 6, 2018*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/scss/partials/_logo.scss
+++ b/src/scss/partials/_logo.scss
@@ -17,10 +17,18 @@ $logo-color--transparent    : $white;
         height: $header-height--narrow;
         padding-top: 18px;
 
+        @if ($theme == 'ml') {
+            padding-top: 12px;
+        }
+
         @include media('>=mid') {
             justify-content: left;
             height: $header-height;
             padding-top: 24px;
+            
+            @if ($theme == 'ml') {
+                padding-top: 18px;
+            }
         }
     }
 }
@@ -33,13 +41,21 @@ $logo-color--transparent    : $white;
             width: 165px;
             height: 32px;
         }
-        // don't apply this to the Menulog logo, as it has multiple fill values built in
-        @if ($theme != 'ml') {
+       
+        @if ($theme == 'je') {
             path {
                 fill: $logo-color;
 
                 .c-header--transparent & {
                     fill: $logo-color--transparent;
+                }
+            }
+        }
+         // Menulog logo, as it has multiple fill values built in. We just hide the outline on transparent mode.
+        @if ($theme == 'ml') {
+            path:first-child {
+                .c-header--transparent & {
+                    display: none;
                 }
             }
         }


### PR DESCRIPTION
- Fixed Menulog logo positioning. Also removed the logo outline in transparent mode so if background colour changes we won't need to update the logo. 

here are the screenshot in different states:
![screenshot 2018-11-06 at 14 25 19](https://user-images.githubusercontent.com/1676440/48070800-a572a000-e1d0-11e8-9ce1-ede01839aaf1.png)
![screenshot 2018-11-06 at 14 24 57](https://user-images.githubusercontent.com/1676440/48070802-a60b3680-e1d0-11e8-9572-e25d5671cd55.png)
![screenshot 2018-11-06 at 14 19 57](https://user-images.githubusercontent.com/1676440/48070803-a60b3680-e1d0-11e8-895e-db6e163331bc.png)
![screenshot 2018-11-06 at 14 19 35](https://user-images.githubusercontent.com/1676440/48070805-a6a3cd00-e1d0-11e8-9e55-094956bd39da.png)

- [x] This PR has been checked with regard to our brand guidelines

