### PR TITLE
v1.1.0 - Update `c-headerButton` position and touch area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v1.1.0
+------------------------------
+*November 7, 2018*
+
+### Changed
+- Updated `.c-header-button` position and increased tap area to size of narrow header.
+
+
 v1.0.2
 ------------------------------
 *November 6, 2018*
@@ -10,12 +19,14 @@ v1.0.2
 ### Fixed
 - Fixed Menulog logo positioning. Also removed the logo outline in transparent mode so if background colour changes we won't need to update the logo. 
 
+
 v1.0.1
 ------------------------------
 *November 6, 2018*
 
 ### Fixed
 - Fixed Menulog logo.
+
 
 v1.0.0
 ------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v1.1.0
 ------------------------------
-*November 7, 2018*
+*November 8, 2018*
 
 ### Changed
 - Updated `.c-header-button` position and increased tap area to size of narrow header.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/scss/partials/_header.scss
+++ b/src/scss/partials/_header.scss
@@ -113,7 +113,7 @@ $header--transparent-opacity        : 0.7;
         z-index: zIndex(belowHighest);
 
         .is-sticky & {
-            top:  $header-button--height  * -1;
+            top:  -#{$header-button--height};
         }
     }
 

--- a/src/scss/partials/_header.scss
+++ b/src/scss/partials/_header.scss
@@ -1,4 +1,6 @@
 $header-height--narrow              : 56px;
+$header-button--height              : 56px;
+$header-button--width               : 56px;
 $header-height                      : 76px;
 $header-height--narrow--multiLang   : $header-height--narrow + $languageSwitcher-height;
 $header-bg                          : $white;
@@ -98,23 +100,27 @@ $header--transparent-opacity        : 0.7;
     // Header button Styling
     // Example – searchWeb filter button at narrow views
     .c-header-button {
+        top: 0;
+        right: 0;
         border: 0;
-        top: 14px;
+        padding: 0;
+        line-height: 1;
         background: none;
         appearance: none;
-        right: spacing();
-        padding: spacing();
         position: absolute;
+        width: $header-button--width;
+        height: $header-button--height;
         z-index: zIndex(belowHighest);
 
         .is-sticky & {
-            top: -47px;
+            top:  $header-button--height  * -1;
         }
     }
 
     .c-header-buttonIcon {
         width: 28px;
-        height: 28px;
+        height: 15px;
+        display: inline-block;
 
         svg {
             fill: $header-buttonIcon-color;

--- a/src/scss/partials/_header.scss
+++ b/src/scss/partials/_header.scss
@@ -1,5 +1,5 @@
 $header-height--narrow              : 56px;
-$header-button--height              : 56px;
+$header-button--height              : $header-height--narrow;
 $header-button--width               : 56px;
 $header-height                      : 76px;
 $header-height--narrow--multiLang   : $header-height--narrow + $languageSwitcher-height;


### PR DESCRIPTION
- Update `c-headerButton` position and touch area

Before:
<img width="653" alt="screen shot 2018-11-07 at 12 45 53" src="https://user-images.githubusercontent.com/5295718/48132634-2f337380-e28c-11e8-837a-1cfe4edf9db0.png">

After:
<img width="564" alt="screen shot 2018-11-07 at 12 35 41" src="https://user-images.githubusercontent.com/5295718/48132637-30fd3700-e28c-11e8-93cd-bb85438b410f.png">

## UI Review Checks

- [x] This PR has been checked with regard to our brand guidelines

## Browsers Tested

- [x] Chrome
- [x] Mobile