### PR TITLE
v1.1.1 Fix invisible text when hovering over header menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.1.1
+------------------------------
+*December §0, 2018*
+
+### Fixed
+- Fixed text colour of the popover menu, on hover.
+
 
 v1.1.0
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/scss/partials/_nav.scss
+++ b/src/scss/partials/_nav.scss
@@ -197,6 +197,10 @@ $nav-popover-padding               : spacing(x2);
                     .c-header--transparent & {
                         color: $nav-text-color--transparent;
                     }
+
+                    .c-header--transparent .c-nav-popoverList & {
+                        color: $grey--dark;
+                    }
                 }
             }
         }

--- a/src/scss/partials/_nav.scss
+++ b/src/scss/partials/_nav.scss
@@ -199,7 +199,7 @@ $nav-popover-padding               : spacing(x2);
                     }
 
                     .c-header--transparent .c-nav-popoverList & {
-                        color: $grey--dark;
+                        color: inherit;
                     }
                 }
             }


### PR DESCRIPTION
Fixed invisible text when hovering over header menu

## Browsers Tested

- [x] Chrome
- [x] Mobile - iPhone

Before:
![before](https://user-images.githubusercontent.com/1676440/49725880-acc01a00-fc64-11e8-8748-8976c2fa05e3.png)
After:
![after](https://user-images.githubusercontent.com/1676440/49725879-acc01a00-fc64-11e8-9841-0de589ce2427.png)



