### PR TITLE
v1.2.0 - Transparent header support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 v1.2.0
 ------------------------------
-*January 29, 2019*
+*January 30, 2019*
 
 ### Added
 - Added `useTransparentHeader` flag for transparent header classes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,18 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v1.2.0
+------------------------------
+*January 29, 2019*
+
+### Added
+- Added `useTransparentHeader` flag for transparent header classes.
+
+
 v1.1.1
 ------------------------------
-*December §0, 2018*
+*December 11, 2018*
 
 ### Fixed
 - Fixed text colour of the popover menu, on hover.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/templates/header/index.hbs
+++ b/src/templates/header/index.hbs
@@ -2,7 +2,7 @@
 
 {{> skip-to }}
 
-<header class="c-header {{headerCssClassModifier}}" data-sticky-element>
+<header class="c-header {{#if useTransparentHeader}}c-header--transparent c-header--gradient{{/if}}" data-sticky-element>
     {{> language-switcher }}
 
     <div class="l-container c-header-wrap">

--- a/src/templates/resources/header-docs-data.json
+++ b/src/templates/resources/header-docs-data.json
@@ -1,7 +1,7 @@
 {
   "language": "en-CA",
   "isMultiLingual": true,
-  "headerCssClassModifier": "",
+  "useTransparentHeader": true,
   "loginUrl": "#",
   "logoutUrl": "#",
   "logoAltText": "Just Eat - Online Takeaway",


### PR DESCRIPTION
Add the appropriate classes for transparent header when the `useTransparentHeader` flag is passed up from the back-end.

## UI Review Checks

- [x] This PR has been checked with regard to our brand guidelines
- [ ] UI Documentation has been [created|updated]
- [x] This code has been checked with regard to our accessibility standards
  - [x] HTML is valid [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#htmlvalid)
  - [x] HTML is semantic [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#htmlsemantic)

## Browsers Tested

- [x] Chrome
- [ ] Edge
- [ ] Internet Explorer 11
- [ ] Mobile (i.e. iPhone/Android - please list device)

### List any other browsers that this PR has been tested in:

- [View the Browser Support Checklist](http://fozzie.just-eat.com/documentation/general/browser-support)