### PR TITLE
v1.3.0 Change login link text + c-skipTo styles amends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.3.0
+------------------------------
+*February 14, 2019*
+
+### Changed
+- 'loginLinkText' from 'Log-in' to 'Log in'
+- `c-skipTo` style amends
+
+
 v1.2.1
 ------------------------------
 *January 30, 2019*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/scss/partials/_skipTo.scss
+++ b/src/scss/partials/_skipTo.scss
@@ -4,12 +4,29 @@
  * Styles relating to the "skip link" element.
  */
 
+
  .c-skipTo {
+    position: absolute;
+    top: 0;
+    left: 0;
+    text-align: center;
+    z-index: zIndex(high);
+
     .is-visuallyHidden {
         &.focusable:active,
         &.focusable:focus {
             display: block;
             margin: 4px;
+            padding: 4px;
+        }
+    }
+}
+
+.c-skipTo--whiteLink {
+    .is-visuallyHidden {
+        &.focusable:active,
+        &.focusable:focus {
+            color: $white;
         }
     }
 }

--- a/src/templates/header/index.hbs
+++ b/src/templates/header/index.hbs
@@ -1,6 +1,10 @@
 {{> order-count }}
 
-{{> skip-to }}
+{{#if useTransparentHeader}}
+    {{> skip-to extraClasses="c-skipTo--whiteLink"}}
+{{else}}
+    {{> skip-to }}
+{{/if}}
 
 <header class="c-header {{#if useTransparentHeader}}c-header--transparent c-header--gradient{{/if}}" data-sticky-element>
     {{> language-switcher }}

--- a/src/templates/header/partials/skip-to.hbs
+++ b/src/templates/header/partials/skip-to.hbs
@@ -1,3 +1,3 @@
-<div class="skipTo">
+<div class="c-skipTo {{ extraClasses }}">
     <a class="is-visuallyHidden focusable u-text-marker" href="#skipToMain">{{ i18n "skipToMainContentText" }}</a>
 </div>

--- a/src/templates/resources/header.json
+++ b/src/templates/resources/header.json
@@ -17,7 +17,7 @@
     "en-AU": {
         "companyName": "Menulog",
         "openMenuText": "Open Menu",
-        "loginLinkText": "Log-in",
+        "loginLinkText": "Log in",
         "loginNoScriptLinkText": "Account",
         "logoAltText": "",
         "helpLinkText": "Help",
@@ -32,7 +32,7 @@
     "en-CA": {
         "companyName": "Just Eat",
         "openMenuText": "Open Menu",
-        "loginLinkText": "Log-in",
+        "loginLinkText": "Log in",
         "loginNoScriptLinkText": "Account",
         "logoAltText": "Just Eat Food Delivery",
         "helpLinkText": "Help",
@@ -49,7 +49,7 @@
     "en-GB": {
         "companyName": "Just Eat",
         "openMenuText": "Open Menu",
-        "loginLinkText": "Log-in",
+        "loginLinkText": "Log in",
         "loginNoScriptLinkText": "Account",
         "logoAltText": "Just Eat - Online Takeaway",
         "helpLinkText": "Help",
@@ -65,7 +65,7 @@
     "en-IE": {
         "companyName": "Just Eat",
         "openMenuText": "Open Menu",
-        "loginLinkText": "Log-in",
+        "loginLinkText": "Log in",
         "loginNoScriptLinkText": "Account",
         "logoAltText": "Just Eat - Order Takeaway",
         "helpLinkText": "Help",
@@ -95,7 +95,7 @@
     "en-NZ": {
         "companyName": "Menulog",
         "openMenuText": "Open Menu",
-        "loginLinkText": "Log-in",
+        "loginLinkText": "Log in",
         "loginNoScriptLinkText": "Account",
         "logoAltText": "",
         "helpLinkText": "Help",


### PR DESCRIPTION
### Changed
- 'loginLinkText' from 'Log-in' to 'Log in'
- `c-skipTo` style amends

![screen shot 2019-02-14 at 16 26 15](https://user-images.githubusercontent.com/19548183/52801199-4812a880-3075-11e9-9139-8616664dda18.png)
