### PR TITLE
v1.5.0 - `is-navInView` class fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.5.0
+------------------------------
+*February 18, 2019*
+
+### Fixed
+- Fixed issue with `is-navInView` class not being applied to narrow header element to stop scrolling of the page.  Also has to add new `is-navInView--noPad` to allow for transparent/fixed headers.
+
+### Changed
+- Tests changed from being snapshots where unnecessary.
+
+
 v1.4.0
 ------------------------------
 *February 15, 2019*
@@ -57,7 +68,7 @@ v1.0.2
 *November 6, 2018*
 
 ### Fixed
-- Fixed Menulog logo positioning. Also removed the logo outline in transparent mode so if background colour changes we won't need to update the logo. 
+- Fixed Menulog logo positioning. Also removed the logo outline in transparent mode so if background colour changes we won't need to update the logo.
 
 
 v1.0.1

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -7,26 +7,45 @@
 import ready from 'lite-ready';
 import { checkForUser } from './userAuth';
 
+const CLASSNAMES = {
+    headerTransparent: 'c-header--transparent'
+};
+
 /**
  * Setup the behaviour for the header component.
  */
 const setupHeader = () => {
-    const menuButton = document.querySelector('[data-nav-button]');
+    const headerEl = document.querySelector('[data-header]');
+    const navButton = document.querySelector('[data-nav-button]');
+    const navToggleLabel = document.querySelector('[data-nav-toggle]');
 
-    if (menuButton) {
-        menuButton.addEventListener('click', () => {
+    if (navButton) {
+        navButton.addEventListener('click', () => {
             const navContainer = document.querySelector('[data-nav-container]');
-            const navLabel = document.querySelector('[data-nav-toggle]');
 
             if (navContainer) {
                 navContainer.classList.toggle('is-visible');
             }
 
-            if (navLabel) {
-                navLabel.classList.toggle('is-open');
+            if (navToggleLabel) {
+                navToggleLabel.classList.toggle('is-open');
             }
 
+            // This is added to remove the ability to scroll the page content when the mobile navigation is open
             document.documentElement.classList.toggle('is-navInView');
+
+            // If the header is already fixed/absolute (as it is when the header is transparent)
+            // then the content doesn't need to be padded down when the nav comes into view, as it's already flush with the top of the screen
+            if (headerEl && headerEl.classList.contains(CLASSNAMES.headerTransparent)) {
+                document.documentElement.classList.toggle('is-navInView--noPad');
+            }
+        });
+    }
+
+    // setup click event on the navigation label, as the button is hidden by default (as used for tabbing only)
+    if (navToggleLabel) {
+        navToggleLabel.addEventListener('click', () => {
+            navButton.click();
         });
     }
 };

--- a/src/js/test/__snapshots__/index.test.js.snap
+++ b/src/js/test/__snapshots__/index.test.js.snap
@@ -1,23 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`setupHeader adds \`is-navInView\` class to html element 1`] = `
+exports[`setupHeader clicking the navigation label, triggers a click on the navigation button element 1`] = `
 "<html class=\\"is-navInView\\"><head></head><body>
             <button data-nav-button=\\"\\"></button>
+            <label data-nav-toggle=\\"\\" class=\\"is-open\\"></label>
         </body></html>"
-`;
-
-exports[`setupHeader adds \`is-open\` class to nav label 1`] = `
-"
-            <button data-nav-button=\\"\\"></button>
-            <label data-nav-toggle=\\"\\" class=\\"is-open\\">Menu</label>
-        "
-`;
-
-exports[`setupHeader adds \`is-visible\` class to nav container 1`] = `
-"
-            <button data-nav-button=\\"\\"></button>
-            <div data-nav-container=\\"\\" class=\\"is-visible\\"></div>
-        "
 `;
 
 exports[`setupHeader does nothing if nav input does not exist 1`] = `

--- a/src/js/test/index.test.js
+++ b/src/js/test/index.test.js
@@ -9,6 +9,10 @@ describe('module', () => {
 });
 
 describe('setupHeader', () => {
+    beforeEach(() => {
+        document.documentElement.className = '';
+    });
+
     it('adds `is-visible` class to nav container', () => {
         // Arrange
         TestUtils.setBodyHtml(`
@@ -22,8 +26,8 @@ describe('setupHeader', () => {
         TestUtils.click(button);
 
         // Assert
-        const html = TestUtils.getBodyHtml();
-        expect(html).toMatchSnapshot();
+        const navContainer = document.querySelector('[data-nav-container]');
+        expect(navContainer.className).toEqual('is-visible');
     });
 
     it('adds `is-open` class to nav label', () => {
@@ -39,8 +43,8 @@ describe('setupHeader', () => {
         TestUtils.click(button);
 
         // Assert
-        const html = TestUtils.getBodyHtml();
-        expect(html).toMatchSnapshot();
+        const label = document.querySelector('[data-nav-toggle]');
+        expect(label.className).toEqual('is-open');
     });
 
     it('does nothing if nav input does not exist', () => {
@@ -71,6 +75,40 @@ describe('setupHeader', () => {
 
         // Act
         TestUtils.click(button);
+
+        // Assert
+        const html = document.documentElement;
+        expect(html.className).toEqual('is-navInView');
+    });
+
+    it('adds `is-navInView--noPad` class to html element if header has `c-header--transparent` class', () => {
+        // Arrange
+        TestUtils.setBodyHtml(`
+            <button data-nav-button></button>
+            <header data-header class="c-header c-header--transparent"></header>
+        `);
+        setupHeader();
+        const button = document.querySelector('[data-nav-button]');
+
+        // Act
+        TestUtils.click(button);
+
+        // Assert
+        const html = document.documentElement;
+        expect(html.className).toEqual('is-navInView is-navInView--noPad');
+    });
+
+    it('clicking the navigation label, triggers a click on the navigation button element', () => {
+        // Arrange
+        TestUtils.setBodyHtml(`
+            <button data-nav-button></button>
+            <label data-nav-toggle></label>
+        `);
+        setupHeader();
+        const label = document.querySelector('[data-nav-toggle]');
+
+        // Act
+        TestUtils.click(label);
 
         // Assert
         const html = document.documentElement.outerHTML;

--- a/src/scss/partials/_logo.scss
+++ b/src/scss/partials/_logo.scss
@@ -25,7 +25,7 @@ $logo-color--transparent    : $white;
             justify-content: left;
             height: $header-height;
             padding-top: 24px;
-            
+
             @if ($theme == 'ml') {
                 padding-top: 18px;
             }

--- a/src/scss/partials/_nav.scss
+++ b/src/scss/partials/_nav.scss
@@ -78,6 +78,15 @@ $nav-popover-padding               : spacing(x2);
     }
 }
 
+// If the header is already fixed/absolute (like when the header is transparent)
+// then the content doesn't need to be padded down when the nav comes into view, as it's already flush with the top of the screen
+// This is added in the f-header JS
+.is-navInView--noPad {
+    body {
+        padding-top: 0;
+    }
+}
+
 // Global site-wide navigation
 .c-nav--global {
     @include media('>=mid') {

--- a/src/templates/header/index.hbs
+++ b/src/templates/header/index.hbs
@@ -6,7 +6,7 @@
     {{> skip-to }}
 {{/if}}
 
-<header class="c-header {{#if useTransparentHeader}}c-header--transparent c-header--gradient{{/if}}" data-sticky-element>
+<header class="c-header {{#if useTransparentHeader}}c-header--transparent c-header--gradient{{/if}}" data-sticky-element data-header>
     {{> language-switcher }}
 
     <div class="l-container c-header-wrap">


### PR DESCRIPTION
### Fixed
- Fixed issue with `is-navInView` class not being applied to narrow header element to stop scrolling of the page.  Also has to add new `is-navInView--noPad` to allow for transparent/fixed headers.

## UI Review Checks

- [x] This code has been checked with regard to our accessibility standards
  - [x] HTML is valid [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#htmlvalid)
  - [x] HTML is well structured [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#htmlstructure)
  - [x] HTML is well ordered [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#htmlorder)
  - [x] HTML is semantic [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#htmlsemantic)
  - [x] HTML is labelled [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#htmllabelled)
  - [x] Passed an accessibility audit [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#audit)
  - [x] Keyboard is supported [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#keyboard)
  - [x] Tab stops in place [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#tabstops)
  - [x] Focus is managed [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#focus)
  - [x] States are updated [[link]](http://fozzie.just-eat.com/documentation/general/accessibility/checklist#state)


## Browsers Tested

- [x] Chrome
- [x] Internet Explorer 11
- [x] Mobile (iPhone 6)
