### PR TITLE
v1.5.1 - Update Header to add 'rel="nofollow" to login page links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.5.1
+------------------------------
+*March 06, 2019*
+
+### Changed
+- Hyperlinks to the login page now include a "rel='nofollow'" html attribute
+
+
 v1.5.0
 ------------------------------
 *February 18, 2019*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/templates/header/index.hbs
+++ b/src/templates/header/index.hbs
@@ -34,13 +34,13 @@
 
                     {{#unless user.isAuthenticated}}
                     <li data-login class="c-nav-list-item {{#unless renderUserMenuOnServer}}is-hidden{{/unless}}" data-test-id="login">
-                        <a href="{{ loginUrl }}" class="c-nav-list-link">
+                        <a href="{{ loginUrl }}" rel="nofollow" class="c-nav-list-link">
                             {{ i18n "loginLinkText" }}
                         </a>
                     </li>
 
                     <li class="c-nav-list-item is-hidden is-shown--noJS" data-test-id="noscript-myaccount">
-                        <a href="{{ loginUrl }}" class="c-nav-list-link">
+                        <a href="{{ loginUrl }}" rel="nofollow" class="c-nav-list-link">
                             {{ i18n "loginNoScriptLinkText" }}
                         </a>
                     </li>


### PR DESCRIPTION
This PR provides an update which ensures links to the login page across the shared header have the rel="nofollow" html attribute, which should help to resolve an SEO related issue reported to the team.

## UI Review Checks
- No visual changes made

## Browsers Tested

- [X] Chrome
- [X] Edge
- [X] Internet Explorer 11
