### PR TITLE
v1.7.0 check for hamburger menu to be closed by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.7.0
+------------------------------
+*March 27, 2019*
+
+### Added
+- Add a check to make sure that hamburger menu is closed when the user navigates back to the page
+
+
 v1.6.0
 ------------------------------
 *March 21, 2019*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v1.7.0
 
 ### Added
 - Add a check to make sure that hamburger menu is closed when the user navigates back to the page
+- Unit test for it
 
 
 v1.6.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -18,6 +18,7 @@ const setupHeader = () => {
     const headerEl = document.querySelector('[data-header]');
     const navButton = document.querySelector('[data-nav-button]');
     const navToggleLabel = document.querySelector('[data-nav-toggle]');
+    const navToggleCheckbox = document.querySelector('[data-nav-accessible-button]');
 
     if (navButton) {
         navButton.addEventListener('click', () => {
@@ -40,6 +41,11 @@ const setupHeader = () => {
                 document.documentElement.classList.toggle('is-navInView--noPad');
             }
         });
+    }
+
+    // make sure that hamburger menu is closed when the user navigates back to the page
+    if (navToggleCheckbox) {
+        navToggleCheckbox.checked = false;
     }
 
     // setup click event on the navigation label, as the button is hidden by default (as used for tabbing only)

--- a/src/js/test/index.test.js
+++ b/src/js/test/index.test.js
@@ -114,4 +114,17 @@ describe('setupHeader', () => {
         const html = document.documentElement.outerHTML;
         expect(html).toMatchSnapshot();
     });
+    it('checks that hamburger menu checkbox is unchecked on every load', () => {
+        // Arrange
+        TestUtils.setBodyHtml(`
+            <input data-nav-accessible-button type="checkbox" checked>
+        `);
+
+        // Act
+        setupHeader();
+
+        // Assert
+        const checkbox = document.querySelector('[data-nav-accessible-button]');
+        expect(checkbox.checked).toEqual(false);
+    });
 });

--- a/src/templates/header/index.hbs
+++ b/src/templates/header/index.hbs
@@ -14,7 +14,7 @@
 
         <nav data-navglobal class="c-nav c-nav--global">
             <button data-nav-button class="c-nav-trigger is-hidden--noJS">{{ i18n "openMenuText" }}</button>
-            <input  data-nav-accessible-button type="checkbox" class="c-nav-trigger is-shown--noJS" id="nav-trigger" />
+            <input data-nav-accessible-button type="checkbox" class="c-nav-trigger is-shown--noJS" id="nav-trigger" />
 
             <label data-nav-toggle class="c-nav-toggle" for="nav-trigger">
                 <span class="c-nav-toggle-icon">{{ i18n "openMenuText" }}</span>


### PR DESCRIPTION
### Added
- Add a check to make sure that hamburger menu is closed when the user navigates back to the page