### PR TITLE
v1.7.1 - Add text overflow ellipsis to better display long user names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.7.1
+------------------------------
+*May 14, 2019*
+
+### Added
+- CSS added to truncate long usernames with an ellipsis
+
+
 v1.7.0
 ------------------------------
 *March 27, 2019*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/scss/partials/_nav.scss
+++ b/src/scss/partials/_nav.scss
@@ -189,9 +189,13 @@ $nav-popover-padding               : spacing(x2);
                 }
             }
         }
-            .c-nav-list-text-sub {
-                display: block;
-            }
+        .c-nav-list-text-sub {
+            display: block;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            max-width: 300px;
+        }
 
         .c-nav-list-link {
             &:hover,

--- a/src/templates/header/index.hbs
+++ b/src/templates/header/index.hbs
@@ -25,7 +25,7 @@
                     <li data-auth-wrapper class="c-nav-list-item has-sublist {{#unless user.isAuthenticated}}is-hidden{{/unless}}" data-test-id="navList" tabindex="0">
                         <p class="c-nav-list-text">
                             {{> nav-icon }}
-                            <span data-name class="c-nav-list-text-sub">{{#if user.isAuthenticated}}{{user.friendlyName}}{{/if}}</span>
+                            <span data-name class="c-nav-list-text-sub"{{#if user.isAuthenticated}} title="{{user.friendlyName}}{{/if}}">{{#if user.isAuthenticated}}{{user.friendlyName}}{{/if}}</span>
                             <span data-email class="c-nav-list-text-sub u-showBelowMid">{{#if user.isAuthenticated}}{{user.email}}{{/if}}</span>
                         </p>
 

--- a/src/templates/header/index.hbs
+++ b/src/templates/header/index.hbs
@@ -25,7 +25,7 @@
                     <li data-auth-wrapper class="c-nav-list-item has-sublist {{#unless user.isAuthenticated}}is-hidden{{/unless}}" data-test-id="navList" tabindex="0">
                         <p class="c-nav-list-text">
                             {{> nav-icon }}
-                            <span data-name class="c-nav-list-text-sub"{{#if user.isAuthenticated}} title="{{user.friendlyName}}{{/if}}">{{#if user.isAuthenticated}}{{user.friendlyName}}{{/if}}</span>
+                            <span data-name class="c-nav-list-text-sub"{{#if user.isAuthenticated}} title="{{user.friendlyName}}"{{/if}}>{{#if user.isAuthenticated}}{{user.friendlyName}}{{/if}}</span>
                             <span data-email class="c-nav-list-text-sub u-showBelowMid">{{#if user.isAuthenticated}}{{user.email}}{{/if}}</span>
                         </p>
 


### PR DESCRIPTION
Long user names can potentially break the header layout, so the text overflow needs to be added to allow longer names without breaking the layout.

## UI Review Checks

Before:
![image](https://user-images.githubusercontent.com/1398088/57704419-c3c2c800-7659-11e9-97da-583c7ef9616e.png)

After:
![image](https://user-images.githubusercontent.com/1398088/57704456-d6d59800-7659-11e9-9483-7acff9121504.png)

## Browsers Tested

- [x] Chrome
- [x] Edge
- [x] Internet Explorer 11
- [ ] Mobile (i.e. iPhone/Android - please list device)
