### PR TITLE
v1.10.0 Remove fill styles from JE logo css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+v1.9.0
+------------------------------
+*May 21, 2019*
+
+### Removed
+- Fill colour for JE logo css
+
 v1.9.0
 ------------------------------
 *May 16, 2019*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/scss/partials/_logo.scss
+++ b/src/scss/partials/_logo.scss
@@ -42,15 +42,6 @@ $logo-color--transparent    : $white;
             height: 32px;
         }
 
-        @if ($theme == 'je') {
-            path {
-                fill: $logo-color;
-
-                .c-header--transparent & {
-                    fill: $logo-color--transparent;
-                }
-            }
-        }
          // Menulog logo, as it has multiple fill values built in. We just hide the outline on transparent mode.
         @if ($theme == 'ml') {
             path:first-child {


### PR DESCRIPTION
Remove fill css styles from JE logo, because it caused weird behavior of the logo colours.

## UI Review Checks

Before:
![Screenshot 2019-05-21 at 11 48 08](https://user-images.githubusercontent.com/19548183/58100948-94bad200-7bd6-11e9-838c-cd8015077f80.png)

After:
![Screen Shot 2019-05-21 at 14 42 12](https://user-images.githubusercontent.com/19548183/58100997-b1570a00-7bd6-11e9-940e-b37a366389f1.png)

