### PR TITLE
v1.11.2 - MENU-3213: Inserts missing translation string for en-GB

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,12 @@ __*This is the standard PR description template.*__
 
 __*Delete the parts of this template that aren’t relevant to the current PR you are submitting – for example, you may not need to amend documentation or testing of the component.*__
 
+To ensure your PR is not auto-rejected:
+
+* Bump the version in package.json
+* Prefix the version number to the PR in the form `v#.#.# - <title>`
+* Edit CHANGELOG.md to describe your changes
+
 ---
 
 _A short description of your PR goes here._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.11.2
+------------------------------
+*August 20, 2019*
+
+### Fixed
+- Adds missing translation string (accountCredit) to en-GB
+
 v1.11.1
 ------------------------------
 *June 19, 2019*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/templates/resources/header.json
+++ b/src/templates/resources/header.json
@@ -57,6 +57,7 @@
         "skipToMainContentText": "Skip to main content",
         "accountInfo": "Your account",
         "accountOrderHistory": "Your orders",
+        "accountCredit": "Account credit",
         "paymentMethods": "Your saved cards",
         "deliveryAddresses": "Your address book",
         "redeemVoucher": "Redeem a voucher",


### PR DESCRIPTION
MENU-3213: Inserts missing translation string for en-GB

## UI Review Checks

No markup/styling changed - used to fix error due to missing string when generating handlebars templates
