### PR TITLE
v1.13.1 - Fixed an issue where the logo disapears on MenuWeb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.13.1
+------------------------------
+*September 18, 2019*
+### Fixed
+- Previous version changed the selector for the logo, which caused it to disapear on MenuWeb, this supports both.
+
 v1.13.0
 ------------------------------
 *September 12, 2019*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/scss/partials/_logo.scss
+++ b/src/scss/partials/_logo.scss
@@ -31,7 +31,7 @@ $logo-color--transparent    : $white;
         }
     }
 }
-    .c-logo-img img {
+    .c-logo-img img, .c-logo-img svg {
         // default logo image height and width (as should be an inline SVG)
         width: 82px;
         height: 16px;


### PR DESCRIPTION
v1.13.1 - Fixed an issue where the logo disapears on MenuWeb

The issue was introduced in 1.13.0, caused by a change to the selector which applies styles to set the logo size. MenuWeb uses an SVG, and the selector was changed to target only IMG.

This PR simply selects both `c-logo-img img, c-logo-img svg`.

Before
![image](https://user-images.githubusercontent.com/10741583/65155919-07717800-da26-11e9-8a8d-7cb299241974.png)


Now
![image](https://user-images.githubusercontent.com/10741583/65155452-3a673c00-da25-11e9-91e9-96a39d7da455.png)