### PR TITLE
v1.32.0 - icing phase 2 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.0.0
+------------------------------
+*October 6, 2021*
+
+### Changed
+- Fozzie updated to version 6.0.0-beta.7 which includes latest pie design tokens.
+- Design changes in line with icing phase 2:
+    - highlight header background from `$color-support-brand` pie value to `$color-support-brand-01`;
+    - nav links colour from `$color-content-link` to `$color-content-interactive-tertiary`;
+    - new border-radius values;
+
+
 v1.31.0
 ------------------------------
 *August 27, 2021*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@justeat/f-logger": "0.7.2",
-    "@justeat/fozzie": "6.0.0-beta.0",
+    "@justeat/fozzie": "6.0.0-beta.7",
     "include-media": "1.4.9",
     "lite-ready": "1.0.4"
   },

--- a/src/scss/partials/_header.scss
+++ b/src/scss/partials/_header.scss
@@ -8,7 +8,7 @@ $header-separator                   : 1px;
 $header-separator                   : 4px;
 $header-border-color                : $color-border-strong;
 $header-buttonIcon-color            : $color-content-brand;
-$header-buttonCount-bg              : $color-support-brand;
+$header-buttonCount-bg              : $color-support-brand-01;
 $header-buttonCount-color           : $color-interactive-light;
 $header-buttonCount-borderColor     : $color-white;
 
@@ -51,6 +51,7 @@ $header--transparent-opacity        : 0.7;
 
     @include media('>=mid') {
         border-bottom: $header-separator solid $header-border-color;
+        border-radius: 0 0 $radius-rounded-d $radius-rounded-d;
     }
 }
 

--- a/src/scss/partials/_nav.scss
+++ b/src/scss/partials/_nav.scss
@@ -7,14 +7,14 @@
 
 $nav-text-size                     : 'body-l';
 $nav-text-font                     : $font-family-base;
-$nav-text-color                    : $color-content-link;
-$nav-text-color--hover             : darken($color-content-link, $color-hover-01);
+$nav-text-color                    : $color-content-interactive-tertiary;
+$nav-text-color--hover             : darken($nav-text-color, $color-hover-01);
 $nav-text-color--transparent       : $color-content-interactive-primary;
 $nav-text-weight                   : $font-weight-bold;
 $nav-text-subFont                  : $font-family-base;
 $nav-text-color--narrow            : $color-content-default;
-$nav-icon-color                    : $color-content-link;
-$nav-icon-color--transparent       : $color-content-link-light;
+$nav-icon-color                    : $nav-text-color;
+$nav-icon-color--transparent       : $nav-text-color--transparent;
 $nav-transition-duration           : 250ms;
 
 $nav-trigger-width                 : 56px;
@@ -34,7 +34,7 @@ $nav-toggleIcon-space              : 5px;
 $nav-tooltip-width                 : 10px;
 
 $nav-popover-width                 : 300px;
-$nav-popover-radius                : 3px;
+$nav-popover-radius                : $radius-rounded-c;
 $nav-popover-transition-duration   : 200ms;
 $nav-popover-transition-delay      : 200ms;
 $nav-popover-padding               : spacing(x2);
@@ -247,10 +247,8 @@ $nav-popover-padding               : spacing(x2);
         right: 99999px; // offscreen, so can’t ever be hovered over by default
         width: $nav-popover-width;
         background-color: $color-container-default;
-        border: 1px solid $color-border-strong;
         box-shadow: 0 2px 40px rgba(0, 0, 0, 0.2);
-        border-top: 0;
-        border-radius: 0 0 $nav-popover-radius $nav-popover-radius;
+        border-radius: $nav-popover-radius;
         padding: 0 $nav-popover-padding;
         opacity: 0;
         z-index: -1;
@@ -273,7 +271,7 @@ $nav-popover-padding               : spacing(x2);
 
         & .c-nav-list-item {
             float: none;
-            border-bottom: 1px solid $color-border-strong;
+            border-bottom: 1px solid $color-border-default;
 
             &:last-child {
                 border-bottom: none;

--- a/yarn.lock
+++ b/yarn.lock
@@ -882,18 +882,17 @@
   resolved "https://registry.yarnpkg.com/@justeat/f-utils/-/f-utils-2.0.0.tgz#34e34870f20ec85b5d0aca8a87e2bc2225e2f597"
   integrity sha512-fFkNH39Qe6sg6e2YZmbh4l4g4qegvpsaEKnj1grCDRspQQvzpmBQBifx6nkHsdaEhetZTJC3LqwOXybmlVJI/g==
 
-"@justeat/fozzie@6.0.0-beta.0":
-  version "6.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-6.0.0-beta.0.tgz#cdd4ddd0b718c2361d33cc1c411d12d061d4c4b9"
-  integrity sha512-BhRJN5OPBoxQQ5H2c+qVgV0104ZVIHn+vcG4Uk+4N6rhWztVJeHIHBYgTvXAeshwkYcvMbItwvcqvDJa3nXcRQ==
+"@justeat/fozzie@6.0.0-beta.7":
+  version "6.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@justeat/fozzie/-/fozzie-6.0.0-beta.7.tgz#d655385225d069448c61007d1ea04d16e065a830"
+  integrity sha512-4mtm7ZxmhVCu/bcEIxJOoZMLzSgrtoxa6QEqtL1ZaBzzyy/mn4lP854PGnmiUAqc/NhNR+gXvHNC/GeoILjm5w==
   dependencies:
     "@justeat/f-dom" "1.1.0"
     "@justeat/f-logger" "0.8.1"
     "@justeat/f-utils" "2.0.0"
-    "@justeat/pie-design-tokens" "1.0.0-beta.0"
+    "@justeat/pie-design-tokens" "1.1.0"
     fontfaceobserver "2.1.0"
     include-media "1.4.10"
-    normalize-scss "7.0.1"
 
 "@justeat/gulp-build-fozzie@8.5.0":
   version "8.5.0"
@@ -976,10 +975,10 @@
     rimraf "^2.6.2"
     vinyl-fs "^2.0.2"
 
-"@justeat/pie-design-tokens@1.0.0-beta.0":
-  version "1.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@justeat/pie-design-tokens/-/pie-design-tokens-1.0.0-beta.0.tgz#272457e7f806ac931800935cd54b10801c45a589"
-  integrity sha512-egiGduhwftk8O9KSnTnK5rN3cP/FY1TurdvFiC12C3mkXEImEZnpLTbf/sZ/StV95m4E69y45jiaPB87FXzSVw==
+"@justeat/pie-design-tokens@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@justeat/pie-design-tokens/-/pie-design-tokens-1.1.0.tgz#d93ad0411cd0457522d8bd466de521382682e05d"
+  integrity sha512-YtiJ7Uq+JZgYAJAFYr0e0an+p8RRk9MimAtqNnk2MFI5au7eNMFt3lTugwfoRgk4jKQfNg2RwTZe0tuuzzc8nw==
   dependencies:
     jsonc-parser "2.2.0"
     lodash.merge "4.6.2"
@@ -10596,11 +10595,6 @@ normalize-range@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
-
-normalize-scss@7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/normalize-scss/-/normalize-scss-7.0.1.tgz#74485e82bb5d0526371136422a09fdb868ffc1a4"
-  integrity sha512-qj16bWnYs+9/ac29IgGjySg4R5qQTp1lXfm7ApFOZNVBYFY8RZ3f8+XQNDDLHeDtI3Ba7Jj4+LuPgz9v/fne2A==
 
 normalize-selector@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
### Changed
- Fozzie updated to version 6.0.0-beta.7 which includes latest pie design tokens.
- Design changes in line with icing phase 2:
    - highlight header background from `$color-support-brand` pie value to `$color-support-brand-01`;
    - nav links colour from `$color-content-link` to `$color-content-interactive-tertiary`;
    - new border-radius values;