### PR TITLE
v1.36.0 – Removing trumps from dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.36.0
+------------------------------
+*November 29, 2022*
+
+### Changed
+- Removed utility call as it causes issues when pulled in alongside fozzie in legacy sites.
+
+### Added
+- Note to README for including utility classes.
+
+
 v1.35.0
 ------------------------------
 *November 2, 2022*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 <h1>f-header</h1>
-  
+
 ## This repo is being deprecated and is only used on sites that cannot currently render Vue components. We recommend switching to using the [Vue.js version of this component as soon as possible](https://github.com/justeat/fozzie-components/tree/master/packages/f-header).
 
 <img width="125" alt="Fozzie Bear" src="bear.png" />
@@ -38,3 +38,11 @@ If you are using the [fozzie gulp build tasks](https://www.npmjs.com/package/@ju
     ```
 
 You can then use the `f-header` fozzie header module styling.
+
+Note that `f-header` uses a number of utility classes from `fozzie`, so in order to display the header as intended fozzie needs to be imported and the following code added to your SCSS:
+
+```scss
+@use '@justeat/fozzie/src/scss/fozzie';
+
+@include f.trumps-utilities();
+```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -27,5 +27,3 @@
 @use 'partials/nav';
 @use 'partials/skipTo';
 
-@include f.trumps-utilities(); // pull in utilities (won't do this if already using this module alongside fozzie)
-


### PR DESCRIPTION
### Changed
- Removed utility call as it causes issues when pulled in alongside fozzie in legacy sites. Added note to README for including utility classes.