### PR TITLE
v1.37.1 – Removing placeholder extend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.37.1
+------------------------------
+*December 1, 2022*
+
+### Fixed
+- Unstyled placeholder extends not coming through correctly since move to `@use`, so hard-coding it instead here.
+
+
 v1.37.0
 ------------------------------
 *November 30, 2022*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-header",
   "description": "Fozzie Header – Header Component for Just Eat projects",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "main": "dist/js/index.js",
   "files": [
     "dist",

--- a/src/scss/partials/_nav.scss
+++ b/src/scss/partials/_nav.scss
@@ -121,7 +121,19 @@ $nav-popover-padding               : f.spacing(d);
 }
 .c-nav-list,
 .c-nav-popoverList {
-    @extend %u-unstyled;
+    margin-top: 0;
+    margin-left: 0;
+    padding: 0;
+    list-style: none;
+    list-style-image: none;
+
+    & > li {
+        margin-bottom: 0;
+
+        &:before {
+            content: none;
+        }
+    }
 
     @include f.media('<mid') {
         display: flex;


### PR DESCRIPTION
### Fixed
- Unstyled placeholder extends not coming through correctly since move to `@use`, so hard-coding it instead here.